### PR TITLE
fix bug in wal and add unittest

### DIFF
--- a/include/lsm/engine.h
+++ b/include/lsm/engine.h
@@ -25,6 +25,7 @@ public:
   std::unordered_map<size_t, std::shared_ptr<SST>> ssts;
   std::shared_mutex ssts_mtx;
   std::shared_ptr<BlockCache> block_cache;
+  std::weak_ptr<TranManager> tran_manager;
   size_t next_sst_id = 0;
   size_t cur_max_level = 0;
 
@@ -65,6 +66,8 @@ public:
   Level_Iterator end();
 
   static size_t get_sst_size(size_t level);
+
+  void set_tran_manager(std::shared_ptr<TranManager> tran_manager);
 
 private:
   void full_compact(size_t src_level);

--- a/include/memtable/memtable.h
+++ b/include/memtable/memtable.h
@@ -55,7 +55,7 @@ public:
 
   void clear();
   std::shared_ptr<SST> flush_last(SSTBuilder &builder, std::string &sst_path,
-                                  size_t sst_id,
+                                  size_t sst_id, std::vector<uint64_t> &flushed_tranc_ids,
                                   std::shared_ptr<BlockCache> block_cache);
   void frozen_cur_table();
   size_t get_cur_size();

--- a/include/utils/set_operation.h
+++ b/include/utils/set_operation.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <set>
+
+template <class T>
+std::set<T> compressSet(const std::set<T>& s) {
+    if (s.empty()) 
+        return std::set<T>();
+    
+    std::set<T> result;
+    auto it = s.begin();
+    T last = *it;
+    ++it;
+    while (it != s.end()) {
+        if (*it == last + 1) {
+            last = *it;
+        } else {
+            break;
+        }
+        ++it;
+    }
+    result.insert(last);
+    while (it != s.end()) {
+        result.insert(*it);
+        ++it;
+    }
+    return result;
+}

--- a/include/wal/wal.h
+++ b/include/wal/wal.h
@@ -18,12 +18,12 @@ namespace tiny_lsm {
 class WAL {
 public:
   WAL(const std::string &log_dir, size_t buffer_size,
-      uint64_t max_finished_tranc_id, uint64_t clean_interval,
+      uint64_t checkpoint_tranc_id, uint64_t clean_interval,
       uint64_t file_size_limit);
   ~WAL();
 
   static std::map<uint64_t, std::vector<Record>>
-  recover(const std::string &log_dir, uint64_t max_finished_tranc_id);
+  recover(const std::string &log_dir, uint64_t checkpoint_tranc_id);
 
   // 将记录添加到缓冲区
   void log(const std::vector<Record> &records, bool force_flush = false);
@@ -31,7 +31,7 @@ public:
   // 强制将缓冲区中的数据写入 WAL 文件
   void flush();
 
-  void set_max_finished_tranc_id(uint64_t max_finished_tranc_id);
+  void set_checkpoint_tranc_id(uint64_t checkpoint_tranc_id);
 
 private:
   void cleaner();
@@ -46,7 +46,7 @@ protected:
   std::vector<Record> log_buffer_;
   size_t buffer_size_;
   std::thread cleaner_thread_;
-  uint64_t max_finished_tranc_id_;
+  uint64_t checkpoint_tranc_id_;
   std::atomic<bool> stop_cleaner_;
   uint64_t clean_interval_;
 };

--- a/src/memtable/memtable.cpp
+++ b/src/memtable/memtable.cpp
@@ -245,7 +245,7 @@ void MemTable::clear() {
 
 // 将最老的 memtable 写入 SST, 并返回控制类
 std::shared_ptr<SST>
-MemTable::flush_last(SSTBuilder &builder, std::string &sst_path, size_t sst_id,
+MemTable::flush_last(SSTBuilder &builder, std::string &sst_path, size_t sst_id, std::vector<uint64_t> &flushed_tranc_ids,
                      std::shared_ptr<BlockCache> block_cache) {
   spdlog::debug("MemTable--flush_last(): Starting to flush memtable to SST{}",
                 sst_id);
@@ -279,6 +279,9 @@ MemTable::flush_last(SSTBuilder &builder, std::string &sst_path, size_t sst_id,
   std::vector<std::tuple<std::string, std::string, uint64_t>> flush_data =
       table->flush();
   for (auto &[k, v, t] : flush_data) {
+    if (k == "" && v == "") {
+      flushed_tranc_ids.push_back(t);
+    }
     max_tranc_id = std::max(t, max_tranc_id);
     min_tranc_id = std::min(t, min_tranc_id);
     builder.add(k, v, t);

--- a/test/test_wal.cpp
+++ b/test/test_wal.cpp
@@ -1,5 +1,6 @@
 #include "../include/logger/logger.h"
 #include "../include/wal/record.h"
+#include "../include/lsm/engine.h"
 #include "../include/wal/wal.h"
 #include <filesystem>
 #include <gmock/gmock.h>
@@ -11,8 +12,8 @@ using namespace ::tiny_lsm;
 class MockWAL : public WAL {
 public:
   MockWAL(const std::string &log_path, size_t buffer_size,
-          uint64_t max_finished_tranc_id)
-      : WAL(log_path, buffer_size, max_finished_tranc_id, 1, 100) {}
+          uint64_t checkpoint_tranc_id)
+      : WAL(log_path, buffer_size, checkpoint_tranc_id, 1, 100) {}
 
   MOCK_METHOD(void, cleaner, ());
   MOCK_METHOD(void, cleanWALFile, ());
@@ -24,11 +25,11 @@ public:
 
   size_t get_file_size_limit() { return file_size_limit_; }
 
-  void set_max_finished_tranc_id(uint64_t max_finished_tranc_id) {
-    max_finished_tranc_id_ = max_finished_tranc_id;
+  void set_checkpoint_tranc_id(uint64_t checkpoint_tranc_id) {
+    checkpoint_tranc_id_ = checkpoint_tranc_id;
   }
 
-  uint64_t get_max_finished_tranc_id() { return max_finished_tranc_id_; }
+  uint64_t get_checkpoint_tranc_id() { return checkpoint_tranc_id_; }
 };
 
 class WALTest : public ::testing::Test {
@@ -47,7 +48,9 @@ protected:
 
   void TearDown() override {
     // 清理测试文件
-    std::filesystem::remove_all(test_dir);
+    if (std::filesystem::exists(test_dir)) {
+      std::filesystem::remove_all(test_dir);
+    }
   }
 
   std::string test_dir = "test_wal_dir";
@@ -153,6 +156,201 @@ TEST_F(WALTest, RecoverTest) {
   for (auto &[tranc_id, records] : tranc_records) {
     EXPECT_EQ(records, expected[tranc_id]);
   }
+}
+
+TEST_F(WALTest, PartialFlushRecoveryTest) {
+  {
+    LSM lsm(test_dir);
+    auto tran_ctx1 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    auto tran_ctx2 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    auto tran_ctx3 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    auto tran_ctx4 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+
+    tran_ctx4->put("key0", "value0");
+
+    tran_ctx2->put("key1", "value1");
+    tran_ctx2->put("key2", "value2");
+    // 提交并刷新wal
+    tran_ctx2->commit();
+    tran_ctx4->commit();
+    tran_ctx1->put("key3", "value3");
+
+    tran_ctx3->put("key4", "value4");
+    // 模拟写入到WAL后系统崩溃
+    tran_ctx1->commit(true);
+  }
+  {
+    LSM lsm(test_dir);
+    EXPECT_EQ(lsm.get("key0").value(), "value0");
+    EXPECT_EQ(lsm.get("key1").value(), "value1");
+    EXPECT_EQ(lsm.get("key2").value(), "value2");
+    EXPECT_EQ(lsm.get("key3").value(), "value3");
+    EXPECT_FALSE(lsm.get("key4").has_value());
+  }
+}
+
+TEST_F(WALTest, ConcurrentTransactionsTest) {
+  {
+    LSM lsm(test_dir);
+    std::vector<std::thread> threads;
+    auto global_ctx = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    for (int j = 0; j < 10; ++j) {
+      global_ctx->put("key" + std::to_string(-1) + "-" + std::to_string(j),
+                "value" + std::to_string(j));
+    }
+    for (int i = 0; i < 40; ++i) {
+      threads.emplace_back([&, i]() {
+        auto ctx = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+        for (int j = 0; j < 1000; ++j) {
+          ctx->put("key" + std::to_string(i) + "-" + std::to_string(j),
+                   "value" + std::to_string(j));
+        }
+        ctx->commit();
+      });
+    }
+    for (auto& t : threads) t.join();
+    lsm.flush_all();
+    for (int j = 10; j < 20; ++j) {
+      global_ctx->put("key" + std::to_string(-1) + "-" + std::to_string(j),
+                "value" + std::to_string(j));
+    }
+    global_ctx->commit(true);
+  }
+
+  // 崩溃恢复后验证
+  
+  {
+    LSM lsm(test_dir);
+    for (int i = 0; i < 40; ++i) {
+      for (int j = 0; j < 100; ++j) {
+        auto val = lsm.get("key" + std::to_string(i) + "-" + std::to_string(j));
+        EXPECT_TRUE(val.has_value());
+        EXPECT_EQ(val.value(), "value" + std::to_string(j));
+      }
+    }
+    for (int j = 0; j < 20; ++j) {
+      auto val = lsm.get("key" + std::to_string(-1) + "-" + std::to_string(j));
+      EXPECT_TRUE(val.has_value());
+      EXPECT_EQ(val.value(), "value" + std::to_string(j));
+    }
+  }
+}
+
+TEST_F(WALTest, HighConcurrencyWithAborts) {
+  // 测试高并发下混合提交和abort
+  const int THREAD_COUNT = 20;
+  const int OPS_PER_THREAD = 100;
+  std::atomic<int> commit_count{0};
+  std::atomic<int> abort_count{0};
+  
+  {
+    LSM lsm(test_dir);
+    std::vector<std::thread> threads;
+    
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      threads.emplace_back([&, i] {
+        auto ctx = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+        bool do_abort = (i % 5 == 0);  // 20%的事务abort
+        
+        for (int j = 0; j < OPS_PER_THREAD; j++) {
+          std::string key = "k" + std::to_string(i) + "_" + std::to_string(j);
+          ctx->put(key, "v" + std::to_string(j));
+          
+          // 随机插入abort
+          if (j == OPS_PER_THREAD / 2 && do_abort) {
+            ctx->abort();
+            abort_count++;
+            return;
+          }
+        }
+        
+        if (do_abort) {
+          ctx->abort();
+          abort_count++;
+        } else {
+          ctx->commit();
+          commit_count++;
+        }
+      });
+    }
+    
+    for (auto& t : threads) t.join();
+  }
+
+  // 恢复验证
+  LSM recovered_lsm(test_dir);
+  int recovered_count = 0;
+  
+  // 验证提交的事务存在，abort的事务不存在
+  for (int i = 0; i < THREAD_COUNT; i++) {
+    bool should_exist = (i % 5 != 0);  // 非abort线程
+    
+    for (int j = 0; j < OPS_PER_THREAD; j++) {
+      std::string key = "k" + std::to_string(i) + "_" + std::to_string(j);
+      auto result = recovered_lsm.get(key);
+      
+      if (should_exist) {
+        EXPECT_TRUE(result.has_value()) << "Missing key: " << key;
+        EXPECT_EQ(result.value(), "v" + std::to_string(j));
+        if (result.has_value()) recovered_count++;
+      } else {
+        EXPECT_FALSE(result.has_value()) << "Aborted key present: " << key;
+      }
+    }
+  }
+  
+  EXPECT_EQ(recovered_count, commit_count * OPS_PER_THREAD);
+}
+
+TEST_F(WALTest, MixedTransactionCommitAbortAndCrashRecovery) {
+  {
+    LSM lsm(test_dir);
+
+    auto t1 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    t1->put("k1", "v1");
+    t1->commit();  // 提交
+
+    auto t2 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    t2->put("k2", "v2");
+    t2->abort();  // 中止
+
+    auto t3 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    // 未提交，也未中止
+    t3->put("k3", "v3");
+
+    auto t5 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    t5->put("k5", "v5");
+    t5->commit();
+
+
+    auto t6 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    t6->put("k6", "v6");
+    t6->commit();
+
+    auto t4 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    t4->put("k4", "v4");
+    t4->commit();
+
+    auto t7 = lsm.begin_tran(IsolationLevel::READ_COMMITTED);
+    t7->put("k7", "v7");
+    t7->commit();
+
+    // 崩溃，t3未提交，t1、t4~t7已提交，t2已中止
+  }
+
+  // 模拟系统重启后的恢复
+  LSM lsm(test_dir);
+
+  // t1、t4~t7 的数据应恢复
+  EXPECT_EQ(lsm.get("k1").value(), "v1");
+  EXPECT_EQ(lsm.get("k4").value(), "v4");
+  EXPECT_EQ(lsm.get("k5").value(), "v5");
+  EXPECT_EQ(lsm.get("k6").value(), "v6");
+  EXPECT_EQ(lsm.get("k7").value(), "v7");
+
+  // t2中止，t3未提交，应该被丢弃
+  EXPECT_FALSE(lsm.get("k2").has_value());
+  EXPECT_FALSE(lsm.get("k3").has_value());
 }
 
 int main(int argc, char **argv) {

--- a/xmake.lua
+++ b/xmake.lua
@@ -212,7 +212,7 @@ target("test_wal")
     set_kind("binary")
     set_group("tests")
     add_files("test/test_wal.cpp")
-    add_deps("logger", "wal")  -- Added memtable and iterator dependencies
+    add_deps("logger", "wal", "lsm")  -- Added memtable and iterator dependencies
     add_includedirs("include")
     add_packages("gtest")
     add_packages("toml11", "spdlog")


### PR DESCRIPTION
If there exist two transactions txn1, txn2, txn2 commits successfully and the system crashes after txn1 writes a WAL.
In the original implementation, flushed_id is the largest tranc_id in the memtable, at which point txn1's WAL is ignored on recovery.
In this implementation, a set is used instead of a single ID to maintain the flush status of transactions. The transaction ID flow is shown below, where ready_to_flush_txn and flush_txn are the sets we need to maintain.

flush_txn is initialized with (0)
flush_txn.size >= 1

1 txn 1 commit act_txn -1-> ready_to_flush_txn
2 txn 2 commit act_txn -2-> ready_to_flush_txn
3 txn 3 commit act_txn -3-> ready_to_flush_txn

4 flush sst0: max_txn is 1 ready_to_flush_txn -1-> flush_txn(0, 1) -> flush_txn(1)
5 flush sst1: max_txn is 2 ready_to_flush_txn -2-> flush_txn(1, 2) -> flush_txn(2)
6 flush sst2: max_txn is 3 ready_to_flush_txn -3-> flush_txn(2, 3) -> flush_txn(3)

7 txn 5 commit act_txn -5-> ready_to_flush_txn
8 txn 4 commit act_txn -4-> ready_to_flush_txn

9 flush sst3: max_txn is 5 ready_to_flush_txn -5-> flush_txn(3, 5, 7, 8, 9, 10)
10 flush sst4: max_txn is 4 ready_to_flush_txn -4-> flush_txn(3, 4, 5) -> flush_txn(5)

checkpoint = flush_txn.begin()