### PR TITLE
fix-thg-bug

### DIFF
--- a/src/utils/bloom_filter.cpp
+++ b/src/utils/bloom_filter.cpp
@@ -1,10 +1,9 @@
 // include/utils/bloom_filter.cpp
 
-#include "../..//include/utils/bloom_filter.h"
+#include "../../include/utils/bloom_filter.h"
 #include <cstring>
 #include <functional>
-#include <iostream>
-#include <numeric>
+#include <cmath>
 #include <string>
 
 namespace tiny_lsm {


### PR DESCRIPTION
# std::log 和 std::ceil 都是 C++ 标准库 <cmath> 里的函数，这个文件确实应该包含 <cmath> 头文件，否则在有些编译器下会报错。
# include "../../include/utils/bloom_filter.h"书写错误，多了一个斜杠