### PR TITLE
将block添加hsah值更新到block::encode

### DIFF
--- a/include/block/block.h
+++ b/include/block/block.h
@@ -57,7 +57,7 @@ public:
   Block() = default;
   Block(size_t capacity);
   // ! 这里的编码函数不包括 hash
-  std::vector<uint8_t> encode();
+  std::vector<uint8_t> encode(bool with_hash = true);
   // ! 这里的解码函数可指定切片是否包括 hash
   static std::shared_ptr<Block> decode(const std::vector<uint8_t> &encoded,
                                        bool with_hash = false);

--- a/src/block/block.cpp
+++ b/src/block/block.cpp
@@ -12,10 +12,13 @@
 namespace tiny_lsm {
 Block::Block(size_t capacity) : capacity(capacity) {}
 
-std::vector<uint8_t> Block::encode() {
+std::vector<uint8_t> Block::encode(bool with_hash) {
   // 计算总大小：数据段 + 偏移数组(每个偏移2字节) + 元素个数(2字节)
   size_t total_bytes = data.size() * sizeof(uint8_t) +
                        offsets.size() * sizeof(uint16_t) + sizeof(uint16_t);
+  if (with_hash) {
+        total_bytes += sizeof(uint32_t); // 预留 hash 空间
+    }
   std::vector<uint8_t> encoded(total_bytes, 0);
 
   // 1. 复制数据段
@@ -33,7 +36,14 @@ std::vector<uint8_t> Block::encode() {
       data.size() * sizeof(uint8_t) + offsets.size() * sizeof(uint16_t);
   uint16_t num_elements = offsets.size();
   memcpy(encoded.data() + num_pos, &num_elements, sizeof(uint16_t));
-
+  // 4. 如果需要hash, 计算并写入hash值
+  if (with_hash) {
+    uint32_t hash_value = std::hash<std::string_view>{}(
+        std::string_view(reinterpret_cast<const char *>(encoded.data()),
+                         total_bytes - sizeof(uint32_t)));
+    memcpy(encoded.data() + total_bytes - sizeof(uint32_t), &hash_value,
+           sizeof(uint32_t));
+  }
   return encoded;
 }
 

--- a/src/sst/sst.cpp
+++ b/src/sst/sst.cpp
@@ -255,19 +255,9 @@ void SSTBuilder::finish_block() {
   auto encoded_block = old_block.encode();
 
   meta_entries.emplace_back(data.size(), first_key, last_key);
-
-  // 计算block的哈希值
-  auto block_hash = static_cast<uint32_t>(std::hash<std::string_view>{}(
-      std::string_view(reinterpret_cast<const char *>(encoded_block.data()),
-                       encoded_block.size())));
-
   // 预分配空间并添加数据
-  data.reserve(data.size() + encoded_block.size() +
-               sizeof(uint32_t)); // 加上的是哈希值
+  data.reserve(data.size() + encoded_block.size());
   data.insert(data.end(), encoded_block.begin(), encoded_block.end());
-  data.resize(data.size() + sizeof(uint32_t));
-  memcpy(data.data() + data.size() - sizeof(uint32_t), &block_hash,
-         sizeof(uint32_t));
 }
 
 std::shared_ptr<SST>


### PR DESCRIPTION
我将block添加hsah值更新到block::encode
理由：方便管理和阅读
- 主要跟新部分
 if (with_hash) {
        total_bytes += sizeof(uint32_t); // 预留 hash 空间
    }
...
 // 4. 如果需要hash, 计算并写入hash值
  if (with_hash) {
    uint32_t hash_value = std::hash<std::string_view>{}(
        std::string_view(reinterpret_cast<const char *>(encoded.data()),
                         total_bytes - sizeof(uint32_t)));
    memcpy(encoded.data() + total_bytes - sizeof(uint32_t), &hash_value,
           sizeof(uint32_t));
  }
- 同时给encode函数添加了一个默认形参， std::vector<uint8_t> encode(bool with_hash = true); 以便于符合其他类中调用此函数无需要再次添加实参，
- 并且新的finish_block函数逻辑如下，void SSTBuilder::finish_block() {
  auto old_block = std::move(this->block);
  auto encoded_block = old_block.encode();

  meta_entries.emplace_back(data.size(), first_key, last_key);
  // 预分配空间并添加数据
  data.reserve(data.size() + encoded_block.size());
  data.insert(data.end(), encoded_block.begin(), encoded_block.end());
}