### PR TITLE
[bug](utils): use pread/pwrite to fix concurrent read race in StdFile

### DIFF
--- a/include/utils/std_file.h
+++ b/include/utils/std_file.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -10,15 +10,28 @@ namespace tiny_lsm {
 class StdFile {
 
 private:
-  std::fstream file_;
+#ifdef _WIN32
+  // 不透明句柄：Windows 下为 HANDLE（void*），避免在头文件引入 windows.h
+  void *handle_ = reinterpret_cast<void *>(static_cast<intptr_t>(-1));
+#else
+  int fd_ = -1;
+#endif
   std::filesystem::path filename_;
 
 public:
-  StdFile() {}
+  StdFile() = default;
   ~StdFile() {
-    if (file_.is_open()) {
+    if (is_open()) {
       close();
     }
+  }
+
+  bool is_open() const {
+#ifdef _WIN32
+    return handle_ != reinterpret_cast<void *>(static_cast<intptr_t>(-1));
+#else
+    return fd_ >= 0;
+#endif
   }
 
   // 打开文件并映射到内存

--- a/src/utils/std_file.cpp
+++ b/src/utils/std_file.cpp
@@ -1,29 +1,167 @@
 #include "utils/std_file.h"
 #include "spdlog/spdlog.h"
-#include <fstream>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
+#include <stdexcept>
 
 #ifdef _WIN32
-#include <io.h>
 #include <windows.h>
-
 #else
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
 namespace tiny_lsm {
 
+#ifdef _WIN32
+// Windows 实现：CreateFile + ReadFile/WriteFile + OVERLAPPED（位置读写）。
+// OVERLAPPED 显式携带偏移，不更新文件指针，同一句柄上并发调用安全，
+// 语义与 POSIX 的 pread/pwrite 对齐。open 时带 FILE_SHARE_DELETE，
+// 允许在句柄仍打开时删除文件（对应 POSIX 的 unlink）。
+
+namespace {
+constexpr void *kInvalidHandle = reinterpret_cast<void *>(static_cast<intptr_t>(-1));
+}
+
 bool StdFile::open(const std::string &filename, bool create) {
   filename_ = filename;
 
-  if (create) {
-    file_.open(filename, std::ios::in | std::ios::out | std::ios::binary |
-                             std::ios::trunc);
-  } else {
-    file_.open(filename, std::ios::in | std::ios::out | std::ios::binary);
+  HANDLE h = CreateFileA(
+      filename.c_str(), GENERIC_READ | GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+      create ? CREATE_ALWAYS : OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+  if (h == INVALID_HANDLE_VALUE) {
+    DWORD err = GetLastError();
+    std::string error_msg =
+        fmt::format("Failed to open file '{}': error code {}", filename, err);
+
+    spdlog::error(error_msg);
+    std::cerr << "[ERROR] " << error_msg << std::endl;
+    return false;
   }
 
-  if (!file_.is_open()) {
+  handle_ = h;
+  return true;
+}
+
+bool StdFile::create(const std::string &filename, std::vector<uint8_t> &buf) {
+  if (!this->open(filename, true)) {
+    throw std::runtime_error("Failed to open file for writing");
+  }
+  if (!buf.empty()) {
+    write(0, buf.data(), buf.size());
+  }
+
+  return true;
+}
+
+void StdFile::close() {
+  if (is_open()) {
+    sync();
+    CloseHandle(static_cast<HANDLE>(handle_));
+    handle_ = kInvalidHandle;
+  }
+}
+
+size_t StdFile::size() {
+  if (!is_open()) {
+    return 0;
+  }
+  LARGE_INTEGER sz;
+  if (!GetFileSizeEx(static_cast<HANDLE>(handle_), &sz)) {
+    return 0;
+  }
+  return static_cast<size_t>(sz.QuadPart);
+}
+
+std::vector<uint8_t> StdFile::read(size_t offset, size_t length) {
+  std::vector<uint8_t> buf(length);
+  size_t done = 0;
+  while (done < length) {
+    OVERLAPPED ov{};
+    ov.Offset = static_cast<DWORD>(offset + done);
+    ov.OffsetHigh = static_cast<DWORD>((offset + done) >> 32);
+    DWORD n = 0;
+    if (!ReadFile(static_cast<HANDLE>(handle_), buf.data() + done,
+                  static_cast<DWORD>(length - done), &n, &ov)) {
+      // EOF（ERROR_HANDLE_EOF）或其它错误统一按读取失败处理，保持原异常语义
+      throw std::runtime_error("Failed to read from file");
+    }
+    if (n == 0) {
+      throw std::runtime_error("Failed to read from file");
+    }
+    done += n;
+  }
+  return buf;
+}
+
+bool StdFile::write(size_t offset, const void *data, size_t size) {
+  if (!is_open()) {
+    return false;
+  }
+  const uint8_t *ptr = static_cast<const uint8_t *>(data);
+  size_t done = 0;
+  while (done < size) {
+    OVERLAPPED ov{};
+    ov.Offset = static_cast<DWORD>(offset + done);
+    ov.OffsetHigh = static_cast<DWORD>((offset + done) >> 32);
+    DWORD n = 0;
+    if (!WriteFile(static_cast<HANDLE>(handle_), ptr + done,
+                   static_cast<DWORD>(size - done), &n, &ov)) {
+      return false;
+    }
+    if (n == 0) {
+      return false;
+    }
+    done += n;
+  }
+  return true;
+}
+
+bool StdFile::sync() {
+  if (!is_open()) {
+    return false;
+  }
+  return FlushFileBuffers(static_cast<HANDLE>(handle_)) != 0;
+}
+
+bool StdFile::remove() {
+  // Windows 下用 DeleteFileW：open 时已带 FILE_SHARE_DELETE，可删除被打开的文件
+  return DeleteFileW(filename_.c_str()) != 0;
+}
+
+bool StdFile::truncate(size_t size) {
+  if (!is_open()) {
+    return false;
+  }
+  LARGE_INTEGER pos;
+  pos.QuadPart = static_cast<LONGLONG>(size);
+  if (!SetFilePointerEx(static_cast<HANDLE>(handle_), pos, nullptr,
+                        FILE_BEGIN)) {
+    return false;
+  }
+  return SetEndOfFile(static_cast<HANDLE>(handle_)) != 0;
+}
+
+#else
+// POSIX 实现（Linux/macOS/BSD）：open + pread/pwrite + fstat。
+// pread/pwrite 每次调用显式携带偏移，不修改文件偏移状态，
+// 同一 fd 上多线程并发读写是安全的（修复 fstream 位置竞争）。
+
+bool StdFile::open(const std::string &filename, bool create) {
+  filename_ = filename;
+
+  int flags = O_RDWR;
+  if (create) {
+    flags |= O_CREAT | O_TRUNC;
+  }
+  fd_ = ::open(filename.c_str(), flags, 0644);
+
+  if (fd_ < 0) {
     // 获取具体的错误信息
     int err = errno;
     std::string error_msg = fmt::format("Failed to open file '{}': {} ({})",
@@ -51,39 +189,73 @@ bool StdFile::create(const std::string &filename, std::vector<uint8_t> &buf) {
 }
 
 void StdFile::close() {
-  if (file_.is_open()) {
+  if (fd_ >= 0) {
     sync();
-    file_.close();
+    ::close(fd_);
+    fd_ = -1;
   }
 }
 
 size_t StdFile::size() {
-  file_.seekg(0, std::ios::end);
-  return file_.tellg();
+  if (fd_ < 0) {
+    return 0;
+  }
+  struct stat st;
+  if (::fstat(fd_, &st) != 0) {
+    return 0;
+  }
+  return static_cast<size_t>(st.st_size);
 }
 
 std::vector<uint8_t> StdFile::read(size_t offset, size_t length) {
   std::vector<uint8_t> buf(length);
-  file_.seekg(offset, std::ios::beg);
-  if (!file_.read(reinterpret_cast<char *>(buf.data()), length)) {
-    throw std::runtime_error("Failed to read from file");
+  size_t done = 0;
+  while (done < length) {
+    ssize_t n = ::pread(fd_, buf.data() + done, length - done,
+                        static_cast<off_t>(offset + done));
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      throw std::runtime_error("Failed to read from file");
+    }
+    if (n == 0) {
+      // EOF：实际读到的字节数不足，保持原 fstream 读不满即失败的语义
+      throw std::runtime_error("Failed to read from file");
+    }
+    done += static_cast<size_t>(n);
   }
   return buf;
 }
 
 bool StdFile::write(size_t offset, const void *data, size_t size) {
-  file_.seekg(offset, std::ios::beg);
-  file_.write(static_cast<const char *>(data), size);
-  // this->sync();
+  if (fd_ < 0) {
+    return false;
+  }
+  const uint8_t *ptr = static_cast<const uint8_t *>(data);
+  size_t done = 0;
+  while (done < size) {
+    ssize_t n = ::pwrite(fd_, ptr + done, size - done,
+                         static_cast<off_t>(offset + done));
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (n == 0) {
+      return false;
+    }
+    done += static_cast<size_t>(n);
+  }
   return true;
 }
 
 bool StdFile::sync() {
-  if (!file_.is_open()) {
+  if (fd_ < 0) {
     return false;
   }
-  file_.flush();
-  return file_.good();
+  return ::fsync(fd_) == 0;
 }
 
 bool StdFile::remove() {
@@ -91,14 +263,12 @@ bool StdFile::remove() {
   return std::remove((const char *)filename_.c_str()) == 0;
 }
 
-// TODO: Windows下的文件截断实现目前有问题搁置
-#ifndef _WIN32
 bool StdFile::truncate(size_t size) {
-  if (file_.is_open())
-    file_.close();
-  int ret = ::truncate(filename_.c_str(), size);
-  file_.open(filename_, std::ios::in | std::ios::out | std::ios::binary);
-  return ret == 0 && file_.is_open();
+  if (fd_ < 0) {
+    return false;
+  }
+  return ::ftruncate(fd_, static_cast<off_t>(size)) == 0;
 }
+
 #endif
 } // namespace tiny_lsm


### PR DESCRIPTION
## BG
After moving compaction out of the global write lock, the compaction thread and the read path (Get) can concurrently read the same SST object. Since StdFile internally uses a single std::fstream, which is not thread-safe, interleaved calls to seekg and read from two threads can result in misaligned reads or truncated data.

## Summary

`StdFile` currently wraps a single `std::fstream` whose read path is
`seekg(offset) + read()`. The get/put position is shared mutable state, so when
the compaction worker and the read path (`get` / `get_batch` / scans) access the
same `SST` object concurrently, the two threads interleave `seekg`/`read` and
corrupt each other's position. This surfaces as nondeterministic crashes:

- `std::runtime_error: invalid block offsets section`
- `std::out_of_range: Read beyond file size`
- `std::runtime_error: Failed to read from file`

The files themselves are not corrupted: after a crash, every SST file can be
independently opened and read back successfully with `SST::open + read_block`.

This PR drops `std::fstream` and replaces it with positional I/O that has no
shared file-offset state, making concurrent access on the same handle safe.

## Changes

- `StdFile` (POSIX: Linux/macOS/BSD) is now backed by `open()` + `pread()` /
  `pwrite()` + `fstat()`:
  - `pread`/`pwrite` take the offset explicitly and never touch the file offset,
    so concurrent calls on the same fd are safe;
  - `size()` uses `fstat` instead of `seekg`/`tellg`;
  - `truncate()` uses `ftruncate`; `sync()` is now `fsync`.
- `StdFile` (Windows) is backed by `CreateFile` + `ReadFile`/`WriteFile` with
  `OVERLAPPED`, which is the Windows equivalent of positional I/O:
  - the offset is carried in `OVERLAPPED.Offset/OffsetHigh` and the file pointer
    is not updated, matching `pread`/`pwrite` semantics;
  - `open()` uses `FILE_SHARE_DELETE` and `remove()` uses `DeleteFileW` so files
    can be unlinked while handles are still open (POSIX `unlink` semantics).
- `read`/`write` loop over short reads/writes (including `EINTR` on POSIX) and
  keep the existing exception behavior on failure/EOF.
- The public `StdFile` interface is unchanged; all callers (`FileObj` → SST /
  WAL / VLog / Cursor) are untouched.
- `<fstream>` is removed entirely from the header; Windows uses an opaque
  handle so `<windows.h>` is not pulled into every translation unit.

## Testing

- Small-config (64KB memtable / 8KB per-memtable) stress:
  `./test_lsm --gtest_filter='LSMTest.Persistence' --gtest_repeat=20`
  — passes repeatedly (failed intermittently before this change).
- `test_lsm` — all cases pass except `TranContextTest`, which is a
  pre-existing, unrelated issue (the `LSM` constructor does not bind the
  transaction manager to the engine).
- 64MB default config — `test_lsm` passes.
- `test_sst`, `test_utils`, `test_block_cache` — pass.
- Note: `test_wal` and `test_wisckey` fail in the current working tree, but
  they fail identically with the original `std::fstream` implementation
  (verified by reverting this change), so they are not regressions from this PR.

## Compatibility

- Linux and macOS share the same POSIX implementation.
- Windows keeps the same interface via Win32 positional I/O; it is compiled
  only under `_WIN32` and is not exercised by the Linux CI.